### PR TITLE
Refactor dashboard UI: remove subtitle and display customer in recent…

### DIFF
--- a/components/Dashboard/Footer.vue
+++ b/components/Dashboard/Footer.vue
@@ -88,7 +88,12 @@ const props = defineProps({
 });
 
 const orderColumns = [
-  { name: "customer", label: "Customer", field: "customer", align: "left" },
+  {
+    name: "customer",
+    label: "Customer",
+    field: (row) => row.customer.name,
+    align: "left",
+  },
   { name: "date", label: "Date", field: "date" },
   { name: "total_price", label: "Amount", field: "total_price" },
   { name: "status", label: "Status", field: "status" },

--- a/components/Dashboard/MainContent.vue
+++ b/components/Dashboard/MainContent.vue
@@ -72,7 +72,6 @@
       <q-card v-else class="chart-card">
         <q-card-section>
           <div class="text-h6">Sales Overview</div>
-          <div class="text-caption text-grey">Last 30 days performance</div>
         </q-card-section>
         <q-separator />
         <q-card-section>


### PR DESCRIPTION
## Summary

Minor UI refinements to the dashboard components for better clarity and usability.

## Changes Made

- **DashboardMainContent**
  - Removed the subtitle text `"Last 30 days performance"` under the Sales Overview chart for a cleaner look

- **DashboardFooter**
  - Enhanced the **Recent Orders** section to include the **customer name** for each orders.

## Before vs After

| Component              | Before                            | After                             |
|------------------------|------------------------------------|------------------------------------|
| Sales Overview chart   | Had subtitle text                 | Removed subtitle                  |
| Recent Orders          | Only showed order ID & total      | Now shows customer name too       |

## Notes
- No functional changes were made to the underlying API calls or store logic.
