### PR TITLE
feature: Add Order page with API integration, filtering, pagination, …

### DIFF
--- a/components/Order/DeleteConfirmation.vue
+++ b/components/Order/DeleteConfirmation.vue
@@ -1,0 +1,23 @@
+<template>
+  <q-dialog v-model="props.deleteDialog">
+    <q-card>
+      <q-card-section>
+        <div class="text-h6">Delete Order</div>
+      </q-card-section>
+
+      <q-card-section>
+        Are you sure you want to delete this order?
+      </q-card-section>
+
+      <q-card-actions align="right">
+        <q-btn flat label="Cancel" color="primary" v-close-popup />
+        <q-btn label="Delete" color="negative" @click="emit('delete')" v-close-popup />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ deleteDialog: boolean }>();
+const emit = defineEmits<{ delete: () => void }>();
+</script>

--- a/components/Order/FilterDialog.vue
+++ b/components/Order/FilterDialog.vue
@@ -1,0 +1,210 @@
+<template>
+  <q-dialog v-model="props.filterDialog" persistent>
+    <q-card style="width: 500px; max-width: 90vw">
+      <q-card-section class="row items-center">
+        <div class="text-h6">Filter Orders</div>
+        <q-space />
+        <q-btn
+          @click="emit('close')"
+          icon="close"
+          flat
+          round
+          dense
+          v-close-popup
+        />
+      </q-card-section>
+
+      <q-card-section class="q-pt-none">
+        <div class="q-gutter-y-md">
+          <q-select
+            v-model="statusFilter"
+            :options="statusOptions"
+            label="Status"
+            outlined
+          />
+        </div>
+
+        <q-input
+          v-model="dateRangeText"
+          label="Date Range"
+          outlined
+          clearable
+          @clear="clearDateRange"
+          readonly
+          class="q-mt-md"
+        >
+          <template v-slot:append>
+            <q-icon name="event" class="cursor-pointer">
+              <q-popup-proxy
+                cover
+                transition-show="scale"
+                transition-hide="scale"
+              >
+                <q-date
+                  v-model="dateRange"
+                  range
+                  mask="YYYY-MM-DD"
+                  :options="validateDateRange"
+                >
+                  <div class="row items-center justify-end q-gutter-sm q-pa-sm">
+                    <q-btn label="Cancel" flat color="primary" v-close-popup />
+                    <q-btn
+                      label="Apply"
+                      color="primary"
+                      @click="applyDateRange"
+                      :disable="!isDateRangeValid"
+                    />
+                  </div>
+                </q-date>
+              </q-popup-proxy>
+            </q-icon>
+          </template>
+
+          <template v-if="errorMessage" v-slot:error>
+            {{ errorMessage }}
+          </template>
+        </q-input>
+      </q-card-section>
+
+      <q-card-actions align="right">
+        <q-btn flat label="Reset" color="primary" @click="resetFilters" />
+        <q-btn
+          label="Apply"
+          color="primary"
+          v-close-popup
+          @click="applyFilters"
+        />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+<script setup lang="ts">
+const props = defineProps({
+  filterDialog: {
+    type: Boolean,
+    required: true,
+  },
+});
+
+const emit = defineEmits(["close", "apply-filters"]);
+
+const statusFilter = ref<string>("");
+const statusOptions = [
+  "pending",
+  "processing",
+  "shipped",
+  "delivered",
+  "cancelled",
+];
+
+// date range
+
+import { date } from "quasar";
+
+const { formatDate } = date;
+
+// Date range model (array with from/to dates)
+const dateRange = ref({
+  from: "",
+  to: "",
+});
+
+// Text display for the input
+const dateRangeText = computed(() => {
+  if (!dateRange.value.from && !dateRange.value.to) return "";
+  if (dateRange.value.from && dateRange.value.to) {
+    return `${formatDate(dateRange.value.from, "MMM D, YYYY")} - ${formatDate(
+      dateRange.value.to,
+      "MMM D, YYYY"
+    )}`;
+  }
+  return "Select date range";
+});
+
+// Validation
+const errorMessage = ref("");
+const isDateRangeValid = computed(() => {
+  return dateRange.value.from && dateRange.value.to;
+});
+
+// Date validation rules
+const validateDateRange = (d: string) => {
+  const selectedDate = new Date(d);
+  const today = new Date();
+
+  return selectedDate <= today;
+};
+
+// Apply the selected range
+const applyDateRange = () => {
+  if (!isDateRangeValid.value) {
+    errorMessage.value = "Please select a valid date range";
+    return;
+  }
+
+  const fromDate = new Date(dateRange.value.from);
+  const toDate = new Date(dateRange.value.to);
+
+  // Additional validation
+  if (fromDate > toDate) {
+    errorMessage.value = "End date must be after start date";
+    return;
+  }
+
+  // Max range validation (e.g., 1 year)
+  const diffTime = Math.abs(toDate.getTime() - fromDate.getTime());
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+  if (diffDays > 365) {
+    errorMessage.value = "Maximum date range is 1 year";
+    return;
+  }
+
+  errorMessage.value = "";
+  // Emit event or save to store
+  console.log("Valid date range:", dateRange.value);
+};
+
+// Clear selection
+const clearDateRange = () => {
+  dateRange.value = { from: "", to: "" };
+  errorMessage.value = "";
+};
+
+// Watch for changes
+watch(
+  dateRange,
+  (newVal) => {
+    if (newVal.from && newVal.to) {
+      applyFilters();
+    }
+  },
+  { deep: true }
+);
+
+// apply filters
+
+const applyFilters = () => {
+  const statusMapper = {
+    pending: 1,
+    processing: 2,
+    shipped: 3,
+    delivered: 4,
+    cancelled: 5,
+  };
+  emit("apply-filters", {
+    status: statusMapper[statusFilter.value],
+    from: dateRange.value.from,
+    to: dateRange.value.to,
+  });
+
+  emit("close");
+};
+
+const resetFilters = () => {
+  statusFilter.value = "";
+  clearDateRange();
+  applyFilters();
+};
+</script>
+<style scoped></style>

--- a/components/Order/Header.vue
+++ b/components/Order/Header.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="row items-center q-mb-md">
+    <div class="text-h4 text-weight-bold q-mb-lg">Orders</div>
+    <q-space />
+    <q-input
+      v-model="searchQuery"
+      outlined
+      dense
+      placeholder="Search orders..."
+      class="q-mr-md"
+      style="width: 300px"
+    >
+      <template v-slot:append>
+        <q-icon name="search" />
+      </template>
+    </q-input>
+    <q-btn
+      color="primary"
+      icon="filter_list"
+      label="Filters"
+      @click="emit('filterDialog')"
+      class="q-mr-sm"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+
+const emit = defineEmits(['filterDialog', 'search'])
+
+const searchQuery = ref("");
+
+const searching = ref(false);
+
+watch(searchQuery, () => {
+    if (searching.value) {
+      clearTimeout(searching.value);
+    }
+    searching.value = setTimeout(() => {
+      emit('search', searchQuery.value);
+    }, 500);
+})
+</script>
+

--- a/components/Order/Loader/StatCard.vue
+++ b/components/Order/Loader/StatCard.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="row q-col-gutter-md q-mb-lg">
+    <q-card v-for="index in 4" :key="index" flat class="stat-card col">
+      <q-card-section>
+        <div class="row items-center">
+          <q-skeleton animation="blink" type="QAvatar" />
+          <div>
+            <div class="text-h5 text-weight-bold">
+              <q-skeleton animation="blink" type="rect" style="width: 100px;" />
+            </div>
+            <div class="text-subtitle2">
+              <q-skeleton animation="blink" type="rect" style="width: 100px;" />
+            </div>
+          </div>
+        </div>
+      </q-card-section>
+    </q-card>
+  </div>
+</template>
+<style scoped>
+.stat-card {
+  transition: transform 0.3s ease;
+}
+.stat-card:hover {
+  transform: translateY(-3px);
+}
+</style>

--- a/components/Order/Loader/Table.vue
+++ b/components/Order/Loader/Table.vue
@@ -1,0 +1,51 @@
+<template>
+  <div class="q-pa-md">
+    <q-markup-table>
+      <thead>
+        <tr>
+          <th class="text-left" style="width: 150px">
+            <q-skeleton animation="blink" type="text" />
+          </th>
+          <th class="text-right">
+            <q-skeleton animation="blink" type="text" />
+          </th>
+          <th class="text-right">
+            <q-skeleton animation="blink" type="text" />
+          </th>
+          <th class="text-right">
+            <q-skeleton animation="blink" type="text" />
+          </th>
+          <th class="text-right">
+            <q-skeleton animation="blink" type="text" />
+          </th>
+          <th class="text-right">
+            <q-skeleton animation="blink" type="text" />
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr v-for="n in 5" :key="n">
+          <td class="text-left">
+            <q-skeleton animation="blink" type="text" width="85px" />
+          </td>
+          <td class="text-right">
+            <q-skeleton animation="blink" type="text" width="50px" />
+          </td>
+          <td class="text-right">
+            <q-skeleton animation="blink" type="text" width="35px" />
+          </td>
+          <td class="text-right">
+            <q-skeleton animation="blink" type="text" width="65px" />
+          </td>
+          <td class="text-right">
+            <q-skeleton animation="blink" type="text" width="25px" />
+          </td>
+          <td class="text-right">
+            <q-skeleton animation="blink" type="text" width="85px" />
+          </td>
+        </tr>
+      </tbody>
+    </q-markup-table>
+  </div>
+</template>

--- a/components/Order/StatCard.vue
+++ b/components/Order/StatCard.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="row q-col-gutter-md q-mb-lg">
+    <q-card
+      v-for="stat in orderStats"
+      :key="stat.title"
+      flat
+      class="stat-card col"
+      :class="stat.color"
+    >
+      <q-card-section>
+        <div class="row items-center">
+          <q-icon :name="stat.icon" size="lg" class="q-mr-md" />
+          <div>
+            <div class="text-h5 text-weight-bold">{{ stat.value }}</div>
+            <div class="text-subtitle2">{{ stat.title }}</div>
+          </div>
+        </div>
+      </q-card-section>
+    </q-card>
+  </div>
+</template>
+<script setup lang="ts">
+const props = defineProps<{ orders: Order[] }>();
+
+const orderStats = computed(() => [
+  {
+    title: "Total Orders",
+    value: props.orders.length,
+    icon: "123",
+    color: "bg-blue-1",
+  },
+  {
+    title: "Processing",
+    value: props.orders.filter((o) => o.status === "processing").length,
+    icon: "pending",
+    color: "bg-orange-1",
+  },
+  {
+    title: "Revenue",
+    value: "₱" + props.orders.reduce((sum, o) => sum + o.total, 0).toFixed(2),
+    icon: "monetization_on",
+    color: "bg-green-1",
+  },
+  {
+    title: "Avg. Order",
+    value:
+      "₱" +
+      (
+        props.orders.reduce((sum, o) => sum + o.total, 0) /
+        (props.orders.length || 1)
+      ).toFixed(2),
+    icon: "bar_chart",
+    color: "bg-purple-1",
+  },
+]);
+</script>
+<style scoped>
+.stat-card {
+  transition: transform 0.3s ease;
+}
+.stat-card:hover {
+  transform: translateY(-3px);
+}
+</style>

--- a/components/Order/Table.vue
+++ b/components/Order/Table.vue
@@ -1,0 +1,266 @@
+<template>
+  <q-card flat bordered class="orders-table">
+    <q-table
+      flat
+      bordered
+      :rows="orders"
+      :columns="columns"
+      row-key="id"
+      v-model:pagination="pagination"
+      :loading="loading"
+      binary-state-sort
+      @request="onRequest"
+    >
+      <!-- Custom header -->
+      <template v-slot:header="props">
+        <q-tr :props="props">
+          <q-th
+            v-for="col in props.cols"
+            :key="col.name"
+            :props="props"
+            class="text-weight-bold"
+          >
+            {{ col.label }}
+          </q-th>
+          <q-th auto-width>Actions</q-th>
+        </q-tr>
+      </template>
+
+      <!-- Custom body cells -->
+      <template v-slot:body="props">
+        <q-tr
+          :props="props"
+          @click="$router.push(`/orders/${props.row.id}`)"
+          class="cursor-pointer"
+        >
+          <q-td v-for="col in props.cols" :key="col.name" :props="props">
+            <template v-if="col.name === 'status'">
+              <q-badge :color="getStatusColor(props.row.status)">
+                {{ props.row.status }}
+              </q-badge>
+            </template>
+            <template v-else-if="col.name === 'customer'">
+              <div class="row items-center">
+                <q-avatar size="sm" class="q-mr-sm">
+                  <img
+                    :src="
+                      props.row.customer?.avatar ||
+                      'https://cdn.quasar.dev/img/avatar.png'
+                    "
+                  />
+                </q-avatar>
+                <div>
+                  <div class="text-weight-bold">
+                    {{ props.row.customer?.name }}
+                  </div>
+                  <div class="text-caption">
+                    {{ props.row.customer?.email }}
+                  </div>
+                </div>
+              </div>
+            </template>
+            <template v-else-if="col.name === 'total'">
+              &#8369;{{ props.row.total.toFixed(2) }}
+            </template>
+            <template v-else-if="col.name === 'created_at'">
+              {{ formatDate(props.row.created_at) }}
+            </template>
+            <template v-else>
+              {{ col.value }}
+            </template>
+          </q-td>
+          <q-td auto-width>
+            <q-btn flat round icon="more_vert" @click.stop>
+              <q-menu auto-close>
+                <q-list style="min-width: 150px">
+                  <q-item
+                    clickable
+                    @click="$router.push(`/orders/${props.row.id}`)"
+                  >
+                    <q-item-section avatar>
+                      <q-icon name="visibility" />
+                    </q-item-section>
+                    <q-item-section>View</q-item-section>
+                  </q-item>
+                  <q-separator />
+                  <q-item
+                    clickable
+                    @click="emit('confirm-delete', props.row.id)"
+                  >
+                    <q-item-section avatar>
+                      <q-icon name="delete" color="negative" />
+                    </q-item-section>
+                    <q-item-section class="text-negative"
+                      >Delete</q-item-section
+                    >
+                  </q-item>
+                </q-list>
+              </q-menu>
+            </q-btn>
+          </q-td>
+        </q-tr>
+      </template>
+
+      <!-- Empty State -->
+      <template v-slot:no-data>
+        <div class="full-width row flex-center q-gutter-sm q-pa-lg">
+          <q-icon name="mdi-package-variant-closed" size="sm" />
+          <span>No orders found</span>
+          <q-btn
+            v-if="searchQuery"
+            flat
+            label="Clear search"
+            @click="searchQuery = ''"
+          />
+        </div>
+      </template>
+    </q-table>
+  </q-card>
+</template>
+<script setup lang="ts">
+interface Order {
+  id: string;
+  status: string;
+  created_at: string;
+  customer: {
+    id: string;
+    name: string;
+    email: string;
+    avatar?: string;
+  };
+  items: Array<{
+    product: {
+      name: string;
+    };
+    quantity: number;
+  }>;
+  total: number;
+}
+
+const props = defineProps<{
+  orders: Order[];
+  page: number;
+  perPage: number;
+  rowsNumber: number;
+}>();
+
+const emit = defineEmits<{
+  (e: "confirm-delete", id: string): void;
+  (e: "request", pagination: any): void;
+}>();
+
+const loading = ref(false);
+
+// Table configuration
+const columns = [
+  {
+    name: "id",
+    required: true,
+    label: "Order ID",
+    align: "left",
+    field: "id",
+    sortable: false,
+  },
+  {
+    name: "customer",
+    label: "Customer",
+    align: "left",
+    field: "customer",
+    sortable: false,
+  },
+  {
+    name: "items",
+    label: "Items",
+    align: "center",
+    field: (row) => row.items?.length,
+    sortable: false,
+  },
+  {
+    name: "status",
+    label: "Status",
+    align: "center",
+    field: "status",
+    sortable: false,
+  },
+  {
+    name: "total",
+    label: "Total",
+    align: "right",
+    field: "total",
+    sortable: false,
+  },
+  {
+    name: "created_at",
+    label: "Date",
+    align: "right",
+    field: "created_at",
+    sortable: false,
+  },
+];
+
+const pagination = ref({
+  page: props.page,
+  rowsPerPage: props.perPage,
+  rowsNumber: props.rowsNumber,
+});
+
+watch(
+  () => props.page,
+  (newPage) => {
+    if (!isNaN(newPage)) {
+      pagination.value.page = newPage;
+      pagination.value.rowsPerPage = props.perPage;
+      pagination.value.rowsNumber = props.rowsNumber;
+    }
+  }
+);
+
+// Table pagination/sorting
+const onRequest = async (props: any) => {
+  emit("request", props.pagination);
+};
+
+// Filtered orders
+// Filters
+const searchQuery = ref("");
+const statusFilter = ref<string[]>([]);
+const dateRange = ref<any>(null);
+const customerFilter = ref<any[]>([]);
+const customerOptions = ref<any[]>([]);
+const statusOptions = [
+  "pending",
+  "processing",
+  "shipped",
+  "delivered",
+  "cancelled",
+];
+
+const getStatusColor = (status: string) => {
+  const statusColors: Record<string, string> = {
+    pending: "orange",
+    processing: "blue",
+    shipped: "teal",
+    delivered: "green",
+    cancelled: "red",
+  };
+  return statusColors[status?.toLowerCase()] || "grey";
+};
+
+const formatDate = (dateString: string) => {
+  return new Date(dateString).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+};
+</script>
+<style scoped>
+.orders-table {
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.q-table {
+  height: calc(100vh - 300px);
+}
+</style>

--- a/pages/orders/[id].vue
+++ b/pages/orders/[id].vue
@@ -1,0 +1,363 @@
+<template>
+  <q-page class="q-pa-lg">
+    <!-- Order Header -->
+    <div class="row items-center q-mb-lg">
+      <q-btn
+        flat
+        round
+        icon="mdi-arrow-left"
+        @click="$router.back()"
+        class="q-mr-md"
+      />
+      <div>
+        <div class="text-h4 text-weight-bold">Order #{{ order.id }}</div>
+        <div class="text-subtitle1 text-grey-7">
+          {{ order.date }} •
+          <q-badge :color="getStatusColor(order.status)" class="q-ml-sm">
+            {{ order.status }}
+          </q-badge>
+        </div>
+      </div>
+    </div>
+
+    <!-- Two Column Layout -->
+    <div class="row q-col-gutter-lg">
+      <!-- Left Column - Order Details -->
+      <div class="col-12 col-md-8">
+        <!-- Order Items -->
+        <q-card class="q-mb-lg">
+          <q-card-section class="bg-grey-2">
+            <div class="text-h6">Items Ordered</div>
+          </q-card-section>
+          <q-separator />
+          <q-card-section>
+            <q-list bordered separator>
+              <q-item
+                v-for="item in order.items"
+                :key="item.id"
+                class="q-pa-md"
+              >
+                <q-item-section avatar>
+                  <q-avatar>
+                    <img
+                      :src="
+                        item.product.image ||
+                        'https://cdn.quasar.dev/img/avatar.png'
+                      "
+                    />
+                  </q-avatar>
+                </q-item-section>
+                <q-item-section>
+                  <q-item-label class="text-weight-bold">{{
+                    item.product.name
+                  }}</q-item-label>
+                  <q-item-label caption>
+                    {{ item.variant.label }} • Qty: {{ item.quantity }}
+                  </q-item-label>
+                </q-item-section>
+                <q-item-section side>
+                  <div class="text-h6">&#8369;{{ item.price }}</div>
+                </q-item-section>
+              </q-item>
+            </q-list>
+          </q-card-section>
+        </q-card>
+
+        <!-- Order Timeline -->
+        <q-card>
+          <q-card-section class="bg-grey-2">
+            <div class="text-h6">Order Timeline</div>
+          </q-card-section>
+          <q-separator />
+          <q-card-section>
+            <q-timeline color="primary">
+              <q-timeline-entry
+                v-for="event in order.timeline"
+                :key="event.timestamp"
+                :title="event.status"
+                :subtitle="formatDateTime(event.timestamp)"
+                :icon="getTimelineIcon(event.status)"
+              >
+                <div>{{ event.description }}</div>
+              </q-timeline-entry>
+            </q-timeline>
+          </q-card-section>
+        </q-card>
+      </div>
+
+      <!-- Right Column - Summary -->
+      <div class="col-12 col-md-4">
+        <!-- Order Summary -->
+        <q-card class="q-mb-lg">
+          <q-card-section class="bg-grey-2">
+            <div class="text-h6">Order Summary</div>
+          </q-card-section>
+          <q-separator />
+          <q-card-section>
+            <q-list dense>
+              <q-item>
+                <q-item-section>Subtotal</q-item-section>
+                <q-item-section side
+                  >&#8369;{{ order.total_price?.toFixed(2) }}</q-item-section
+                >
+              </q-item>
+              <q-separator class="q-my-sm" />
+              <q-item class="text-h6">
+                <q-item-section>Total</q-item-section>
+                <q-item-section side
+                  >&#8369;{{ order.total_price?.toFixed(2) }}</q-item-section
+                >
+              </q-item>
+            </q-list>
+          </q-card-section>
+        </q-card>
+
+        <!-- Customer Info -->
+        <q-card class="q-mb-lg">
+          <q-card-section class="bg-grey-2">
+            <div class="text-h6">Customer</div>
+          </q-card-section>
+          <q-separator />
+          <q-card-section>
+            <div class="row items-center q-mb-md">
+              <q-avatar size="lg" class="q-mr-sm">
+                <img
+                  :src="
+                    order.customer.avatar ||
+                    'https://cdn.quasar.dev/img/avatar.png'
+                  "
+                />
+              </q-avatar>
+              <div>
+                <div class="text-weight-bold">{{ order.customer?.name }}</div>
+                <div class="text-caption">{{ order.customer?.email }}</div>
+              </div>
+            </div>
+            <q-list dense>
+              <q-item>
+                <q-item-section avatar>
+                  <q-icon name="phone" />
+                </q-item-section>
+                <q-item-section>{{
+                  order.customer?.phone || "Not provided"
+                }}</q-item-section>
+              </q-item>
+            </q-list>
+          </q-card-section>
+        </q-card>
+
+        <!-- Order Actions -->
+        <q-card v-if="order.status.toLowerCase() != 'cancelled'">
+          <q-card-section class="bg-grey-2">
+            <div class="text-h6">Order Actions</div>
+          </q-card-section>
+          <q-separator />
+          <q-card-section>
+            <div class="q-gutter-y-sm">
+              <q-btn
+                v-if="order?.status.toLowerCase() === 'pending'"
+                color="positive"
+                label="Approve Order"
+                class="full-width"
+                @click="approveOrder(order.id)"
+              />
+
+              <q-btn
+                v-if="order?.status.toLowerCase() === 'processing'"
+                color="primary"
+                label="Mark as Shipped"
+                class="full-width"
+                @click="shipOrder(order.id)"
+              />
+              <q-btn
+                color="negative"
+                outline
+                label="Cancel Order"
+                class="full-width"
+                @click="confirmCancel(order.id)"
+              />
+            </div>
+          </q-card-section>
+        </q-card>
+      </div>
+    </div>
+
+    <!-- Cancel Order Dialog -->
+    <q-dialog v-model="cancelDialog">
+      <q-card style="width: 500px; max-width: 90vw">
+        <q-card-section>
+          <div class="text-h6">Cancel Order</div>
+        </q-card-section>
+        <q-card-section>
+          <q-input
+            v-model="cancelReason"
+            label="Reason for cancellation"
+            outlined
+            type="textarea"
+            autogrow
+          />
+        </q-card-section>
+        <q-card-actions align="right">
+          <q-btn flat label="Cancel" color="primary" v-close-popup />
+          <q-btn label="Confirm" color="negative" @click="cancelOrder" />
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
+  </q-page>
+</template>
+
+<script setup lang="ts">
+interface Order {
+  id: string;
+  status: string;
+  created_at: string;
+  items: Array<{
+    id: string;
+    product: {
+      id: string;
+      name: string;
+      image?: string;
+    };
+    variant: {
+      id: string;
+      label: string;
+    };
+    quantity: number;
+    price: number;
+  }>;
+  subtotal: number;
+  tax: number;
+  shipping: number;
+  total: number;
+  customer: {
+    id: string;
+    name: string;
+    email: string;
+    phone?: string;
+    avatar?: string;
+  };
+  shipping_address: {
+    line1: string;
+    line2?: string;
+    city: string;
+    state: string;
+    postal_code: string;
+    country: string;
+  };
+  timeline: Array<{
+    status: string;
+    timestamp: string;
+    description: string;
+  }>;
+}
+
+// Sample data - replace with your actual data fetching
+const order = ref<Order>({});
+
+const cancelDialog = ref(false);
+const cancelReason = ref("");
+const orderToCancel = ref("");
+
+const orderRepository = useOrdersRepository();
+
+const showOrder = async (id: string) => {
+  const { data } = await useAsyncData(`showOrder-${id}`, () =>
+    orderRepository.showOrder(id)
+  );
+
+  order.value = data.value.data;
+};
+
+await showOrder(useRoute().params.id);
+
+// Helper functions
+const formatDate = (dateString: string) => {
+  return new Date(dateString).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+};
+
+const formatDateTime = (dateString: string) => {
+  return new Date(dateString).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};
+
+const getStatusColor = (status: string) => {
+  const statusColors: Record<string, string> = {
+    Pending: "orange",
+    Processing: "blue",
+    Shipped: "teal",
+    Delivered: "positive",
+    Cancelled: "negative",
+  };
+  return statusColors[status] || "grey";
+};
+
+const getTimelineIcon = (status: string) => {
+  const statusIcons: Record<string, string> = {
+    Pending: "access_time",
+    Processing: "account_balance_wallet",
+    Shipped: "airport_shuttle",
+    Delivered: "check",
+    Cancelled: "close",
+  };
+  return statusIcons[status] || "information";
+};
+
+// Order actions
+const confirmCancel = (orderId: string) => {
+  orderToCancel.value = orderId;
+  cancelDialog.value = true;
+};
+
+const cancelOrder = async () => {
+  console.log(
+    "Cancelling order",
+    orderToCancel.value,
+    "with reason:",
+    cancelReason.value
+  );
+  cancelDialog.value = false;
+  cancelReason.value = "";
+
+  order.value.status = "Cancelled";
+  order.value.timeline.push({
+    status: "Cancelled",
+    timestamp: new Date().toISOString(),
+    description: `Order cancelled: ${cancelReason.value}`,
+  });
+};
+
+const approveOrder = async (orderId: string) => {
+  order.value.status = "Processing";
+  order.value.timeline.push({
+    status: "Processing",
+    timestamp: new Date().toISOString(),
+    description: "Order approved and is being processed",
+  });
+};
+
+const shipOrder = async (orderId: string) => {
+  order.value.status = "Shipped";
+  order.value.timeline.push({
+    status: "Shipped",
+    timestamp: new Date().toISOString(),
+    description: "Order has been shipped to customer",
+  });
+};
+</script>
+
+<style scoped>
+.order-card {
+  transition: transform 0.3s ease;
+}
+.order-card:hover {
+  transform: translateY(-2px);
+}
+</style>

--- a/pages/orders/[id].vue
+++ b/pages/orders/[id].vue
@@ -251,7 +251,7 @@ interface Order {
   }>;
 }
 
-// Sample data - replace with your actual data fetching
+// Order data
 const order = ref<Order>({});
 
 const cancelDialog = ref(false);

--- a/pages/orders/index.vue
+++ b/pages/orders/index.vue
@@ -1,0 +1,211 @@
+<template>
+  <q-page class="q-pa-lg">
+    <!-- Page Header -->
+    <OrderHeader @search="searchOrders" @filter-dialog="filterDialog = true" />
+
+    <!-- Stats Cards -->
+    <OrderLoaderStatCard v-if="getAllOrdersStatus === 'Pending'" />
+    <OrderStatCard v-else :orders="allOrders" />
+
+    <!-- Orders Table -->
+    <OrderLoaderTable v-if="getPaginateOrdersStatus === 'Pending'" />
+    <OrderTable
+      v-else
+      :orders="paginateOrders"
+      :page="page"
+      :per-page="perPage"
+      :rowsNumber="rowsNumber"
+      @confirm-delete="confirmDelete"
+      @request="onPageRequest"
+    />
+
+    <!-- Filter Dialog -->
+    <OrderFilterDialog
+      :filter-dialog="filterDialog"
+      @close="filterDialog = false"
+      @apply-filters="applyFilters"
+    />
+
+    <!-- Delete Confirmation -->
+    <OrderDeleteConfirmation
+      :delete-dialog="deleteDialog"
+      @delete="deleteOrder"
+    />
+  </q-page>
+</template>
+
+<script setup lang="ts">
+interface Order {
+  id: string;
+  status: string;
+  created_at: string;
+  customer: {
+    id: string;
+    name: string;
+    email: string;
+    avatar?: string;
+  };
+  items: Array<{
+    product: {
+      name: string;
+    };
+    quantity: number;
+  }>;
+  total: number;
+}
+
+const ordersRepository = useOrdersRepository();
+const paginateOrders = ref<Order[]>([]);
+const getPaginateOrdersStatus = ref<string>("Pending");
+
+const page = ref(1);
+const perPage = ref(10);
+const rowsNumber = ref(0);
+
+const getPaginateOrders = async (
+  pageNumber = 1,
+  perPageNumber = 10,
+  search = ""
+) => {
+  const { status, data: customerOrders } = await useAsyncData(
+    `getOrders-${pageNumber}`,
+    () =>
+      ordersRepository.getOrders({
+        page: pageNumber,
+        per_page: perPageNumber,
+        search: search,
+      }),
+    {
+      transform: (orders) => {
+        return {
+          data: orders.data.map((order) => ({
+            id: order.id,
+            status: order.status,
+            created_at: order.date,
+            customer: order.customer,
+            items: order.items,
+            total: order.total_price,
+          })),
+          links: orders.links,
+          meta: orders.meta,
+        };
+      },
+    }
+  );
+
+  getPaginateOrdersStatus.value = status;
+  paginateOrders.value = customerOrders.value.data ?? [];
+  page.value = parseInt(customerOrders?.value?.meta?.current_page);
+  perPage.value = parseInt(customerOrders?.value?.meta?.per_page);
+  rowsNumber.value = parseInt(customerOrders?.value?.meta?.last_page);
+};
+
+getPaginateOrders();
+
+const allOrders = ref<Order[]>([]);
+const getAllOrdersStatus = ref("Pending");
+
+const getAllOrders = async () => {
+  const { status, data: customerOrders } = await useAsyncData(
+    `getOrders`,
+    () =>
+      ordersRepository.getOrders({
+        month: "this month",
+      }),
+    {
+      transform: (orders) =>
+        orders.data.map((order) => ({
+          id: order.id,
+          status: order.status,
+          created_at: order.date,
+          customer: order.customer,
+          items: order.items,
+          total: order.total_price,
+        })),
+    }
+  );
+
+  getAllOrdersStatus.value = status;
+  allOrders.value = customerOrders.value ?? [];
+  page.value = parseInt(customerOrders.value.meta?.current_page) ?? 1;
+  perPage.value = parseInt(customerOrders.value.meta?.per_page) ?? 10;
+  rowsNumber.value = parseInt(customerOrders.value.meta?.last_page) ?? 0;
+};
+
+getAllOrders();
+
+const filterDialog = ref(false);
+const deleteDialog = ref(false);
+const orderToDelete = ref("");
+
+const searchText = ref("");
+const searchOrders = async (searchQuery: string) => {
+  searchText.value = searchQuery;
+  onPageRequest({
+    page: page.value,
+    rowsPerPage: perPage.value,
+    rowsNumber: rowsNumber.value,
+  });
+};
+
+const statusFilter = ref("");
+const fromFilter = ref("");
+const toFilter = ref("");
+const applyFilters = async ({
+  status,
+  from,
+  to,
+}: {
+  status: number;
+  from: string;
+  to: string;
+}) => {
+  statusFilter.value = status;
+  fromFilter.value = from;
+  toFilter.value = to;
+  onPageRequest({
+    page: page.value,
+    rowsPerPage: perPage.value,
+    rowsNumber: rowsNumber.value,
+  });
+};
+
+const onPageRequest = async (pagination: any) => {
+  const data = await ordersRepository.getOrders({
+    page: pagination.page,
+    per_page: pagination.rowsPerPage,
+    search: searchText.value,
+    status: statusFilter.value,
+    start_date: fromFilter.value,
+    end_date: toFilter.value,
+  });
+
+  paginateOrders.value = data.data.map((order) => ({
+    id: order.id,
+    status: order.status,
+    created_at: order.date,
+    customer: order.customer,
+    items: order.items,
+    total: order.total_price,
+  }));
+
+  page.value = parseInt(data.meta?.current_page) ?? 1;
+  perPage.value = parseInt(data.meta?.per_page) ?? 10;
+  rowsNumber.value = parseInt(data.meta?.last_page) ?? 0;
+};
+
+// Order actions
+const confirmDelete = (orderId: string) => {
+  orderToDelete.value = orderId;
+  deleteDialog.value = true;
+};
+
+const deleteOrder = () => {
+  paginateOrders.value = paginateOrders.value.filter(
+    (o) => o.id !== orderToDelete.value
+  );
+  deleteDialog.value = false;
+};
+</script>
+
+<style scoped></style>

--- a/pages/register.vue
+++ b/pages/register.vue
@@ -1,0 +1,11 @@
+<template>
+    <div>
+        register
+    </div>
+</template>
+
+<script setup lang="ts">
+definePageMeta({
+    layout: "guest",
+});
+</script>

--- a/repositories/ordersRepository.ts
+++ b/repositories/ordersRepository.ts
@@ -19,5 +19,9 @@ export const useOrdersRepository = () => {
     getOrders: async (options: any) => {
       return await api.get<Order[]>("/v1/orders", options);
     },
+
+    showOrder: async (id: string) => {
+      return await api.get<Order>(`/v1/orders/${id}`);
+    },
   };
 };


### PR DESCRIPTION
## Summary

This pull request introduces the **Order Page** with full API integration and interactivity.

## Features Implemented

- **Order Listing Page**:
  - Fetches orders from the backend using `ordersRepository.getOrders(...)`
  - Supports **searching** by reference ID and customer name
  - Supports **pagination**
  - Supports **date filtering**
  - Displays key order data including reference ID, customer, status, total price, and order date

- **Interactive Table Rows**:
  - Rows are **clickable** and can navigate to the detailed view of an order (e.g., `/orders/:id`)

## Notes

- Server-side filtering is scoped using Eloquent's `scopeSearch`, `scopeStatus`, and `scopeBetweenDates` methods
- Default pagination limit is `10` per page or defined by the .env
